### PR TITLE
Greenhouse.io job board

### DIFF
--- a/src/templates/team.js
+++ b/src/templates/team.js
@@ -4,8 +4,6 @@ import remark from 'remark'
 import recommended from 'remark-preset-lint-recommended'
 import remarkHtml from 'remark-html'
 import { graphql } from 'gatsby'
-import Helmet from  'react-helmet'
-import { PostScribe } from 'react-postscribe'
 import Layout from '../components/layout'
 import Hero from '../components/hero'
 import Block from '../components/block'
@@ -26,12 +24,9 @@ export const TeamTemplate = ({
 }) => (
   <div>
     {!preview && (
-        <div>
-          <SEO title={title} description={subtitle}></SEO>
-          <Helmet>
-            <script src="https://www.workable.com/assets/embed.js" type="text/javascript"></script>
-          </Helmet>
-        </div>
+      <div>
+        <SEO title={title} description={subtitle}></SEO>
+      </div>
     )}
     <Hero
       title={title}
@@ -52,21 +47,11 @@ export const TeamTemplate = ({
       <Prose>
         <div className={'mb-10'} dangerouslySetInnerHTML={{__html: join_body}}></div>
         {!preview && (
-          <PostScribe html={`
-            <div class="text-2xl font-semibold pb-1 mb-4 border-b border-grey">Here’s what’s available now.</div>
-            <script>
-              function checkVariable() {
-                if (window.whr) {
-                  whr(document).ready(function(){whr_embed(357587, {detail: 'titles', base: 'jobs', zoom: 'country', grouping: 'none'});});
-                } else {
-                  setTimeout(checkVariable, 1000);
-                }
-              }
-
-              setTimeout(checkVariable, 50);
-            </script>
-            <div id='whr_embed_hook'></div>
-          `} />
+          <>
+            <div className="text-2xl font-semibold pb-1 mb-4 border-b border-grey">Here’s what’s available now.</div>
+            <div id="grnhse_app" />
+            <script src="https://boards.greenhouse.io/embed/job_board/js?for=agilesix"></script>
+          </>
         )}
       </Prose>
     </Block>

--- a/src/templates/team.js
+++ b/src/templates/team.js
@@ -48,9 +48,7 @@ export const TeamTemplate = ({
         <div className={'mb-10'} dangerouslySetInnerHTML={{__html: join_body}}></div>
         {!preview && (
           <>
-            <div className="text-2xl font-semibold pb-1 mb-4 border-b border-grey">Here’s what’s available now.</div>
-            <div id="grnhse_app" />
-            <script src="https://boards.greenhouse.io/embed/job_board/js?for=agilesix"></script>
+            <a href="https://boards.greenhouse.io/agilesix">Browse Open Positions</a>
           </>
         )}
       </Prose>

--- a/src/templates/team.js
+++ b/src/templates/team.js
@@ -48,7 +48,12 @@ export const TeamTemplate = ({
         <div className={'mb-10'} dangerouslySetInnerHTML={{__html: join_body}}></div>
         {!preview && (
           <>
-            <a href="https://boards.greenhouse.io/agilesix">Browse Open Positions</a>
+            <p>
+              <strong>Apply to work at Agile Six</strong>
+            </p>
+            <p>
+              <a style={{fontSize: '1.5rem'}} href="https://boards.greenhouse.io/agilesix">Browse Current Open Positions</a>
+            </p>
           </>
         )}
       </Prose>


### PR DESCRIPTION
Basic greenhouse.io job board integration.  We had a few issues attempting the iframe integration technique, so we're starting with the basic "link to external greenhouse.io job board" version (Option 1 in the greenhouse.io [integration options](https://app3.greenhouse.io/configure/dev_center/integration)).

In a follow-up, we'll look into using the greenhouse API to fetch job board data so that we can render it inside of our site and style it appropriately (Option 3 in the greenhouse.io [integration options](https://app3.greenhouse.io/configure/dev_center/integration)).

Below is a screenshot of the updated teams page using job board link.

![Screen Shot 2020-07-27 at 3 02 58 PM](https://user-images.githubusercontent.com/54035677/88596619-5448b680-d01a-11ea-9860-222a2f63e09d.png)