### PR TITLE
Tailwind Darkmode Override

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 // tailwind.config.js
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/**/*.{js,jsx,ts,tsx}',
     './src/pages/**/*.{js,jsx,ts,tsx}',


### PR DESCRIPTION
Tailwind introduced new darkmode color via system preferences, this change adds an override that will make the site look for a darkmode class instead of allowing the system to determine the color.

Fix
![Screen Shot 2022-10-20 at 8 40 47 AM](https://user-images.githubusercontent.com/3916436/196995108-d9e5b59d-1c6a-4dc0-87d7-5f8190ae7fbd.png)
